### PR TITLE
update: 使用通义千问大模型

### DIFF
--- a/QwenLLM.py
+++ b/QwenLLM.py
@@ -1,0 +1,135 @@
+from typing import (
+    Any,
+    Optional,
+    Sequence,
+)
+
+from llama_index.bridge.pydantic import Field
+from llama_index.llms.base import (
+    llm_chat_callback,
+    llm_completion_callback,
+)
+from llama_index.llms.llm import LLM
+from llama_index.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
+    ChatResponseGen,
+    CompletionResponse,
+    CompletionResponseAsyncGen,
+    CompletionResponseGen,
+    LLMMetadata,
+)
+
+DEFAULT_MODEL = "qwen-turobo"
+#export DASHSCOPE_API_KEY="YOUR_KEY"
+
+import random
+from http import HTTPStatus
+import dashscope
+
+class QwenUnofficial(LLM) :
+    model: str = Field(
+        default=DEFAULT_MODEL, description="The QWen model to use."
+    )
+
+    max_tokens: Optional[int] = Field(
+        description="The maximum number of tokens to generate.",
+        gt=0,
+    )
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        temperature: float = 0.1,
+        max_tokens: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None :
+
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+
+    # Qwen 官方案例
+    def call_with_prompt( self, prompt ):
+        response = dashscope.Generation.call(
+            model=dashscope.Generation.Models.qwen_max,
+            prompt=prompt
+        )
+
+        # 如果API一直有问题
+        # 可以直接复制prompt到网页去问
+        # print( prompt )
+
+        # The response status_code is HTTPStatus.OK indicate success,
+        # otherwise indicate request is failed, you can get error code
+        # and message from code and message.
+        if response.status_code == HTTPStatus.OK:
+            return response.output["text"]
+        else:
+            errMessage = (
+                "通义模型API返回的错误: \n"
+                "Error Code: " + response.code + "\n"
+                "Error Message: " + response.message + "\n"
+                "Request ID: " + response.request_id 
+            )
+
+            raise Exception( errMessage ) 
+
+    @llm_completion_callback()
+    def complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        answer = self.call_with_prompt( prompt )
+
+        return CompletionResponse(
+            text=answer,
+        )
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(
+            context_window=6000,
+            num_output=self.max_tokens or -1,
+            # is_chat_model=is_chat_model(model=self._get_model_name()),
+            is_chat_model=False,
+            is_function_calling_model=False,
+            # is_function_calling_model=is_function_calling_model(
+            #     model=self._get_model_name()
+            # ),
+            model_name=self.model,
+        )
+
+    # 下面是实现Interface必要的方法
+    # 但这里用不到，所以都是pass
+    @llm_completion_callback()
+    async def astream_complete() -> CompletionResponseAsyncGen:
+        pass
+
+    async def _astream_chat() -> ChatResponseAsyncGen:
+        pass
+
+    @llm_chat_callback()
+    async def astream_chat() -> ChatResponseAsyncGen:
+        pass
+
+    @llm_chat_callback()
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        pass
+
+    @llm_chat_callback()
+    def stream_chat() -> ChatResponseGen:
+        pass
+    
+    @llm_completion_callback()
+    def stream_complete() -> CompletionResponseGen:
+        pass
+
+    @llm_chat_callback()
+    async def achat() -> ChatResponse:
+        pass
+    
+    @llm_completion_callback()
+    async def acomplete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        pass

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 llm:
-    name: "gpt-4"
+    name: "qwen"
     temperature: 0.01
 embedding:
     name: "BAAI/bge-base-zh-v1.5"

--- a/custom/llms/QwenLLM.py
+++ b/custom/llms/QwenLLM.py
@@ -21,7 +21,7 @@ from llama_index.llms.types import (
     LLMMetadata,
 )
 
-DEFAULT_MODEL = "qwen-turobo"
+DEFAULT_MODEL = "qwen-max"
 #export DASHSCOPE_API_KEY="YOUR_KEY"
 
 import random

--- a/executor.py
+++ b/executor.py
@@ -12,6 +12,7 @@ from llama_index import ServiceContext, StorageContext
 from llama_index import set_global_service_context
 from llama_index import VectorStoreIndex, SimpleDirectoryReader, Document
 from llama_index.llms import OpenAI
+from QwenLLM import QwenUnofficial
 from llama_index.readers.file.flat_reader import FlatReader
 from llama_index.vector_stores import MilvusVectorStore
 from llama_index.embeddings import HuggingFaceEmbedding
@@ -104,7 +105,13 @@ class MilvusExecutor(Executor):
             original_text_metadata_key="original_text",)
 
         embed_model = HuggingFaceEmbedding(model_name=config.embedding.name)
-        llm = OpenAI(temperature=config.llm.temperature, model=config.llm.name, max_tokens=2048)
+
+        # 使用Qwen 通义千问模型
+        if config.llm.name == "qwen":
+            llm = QwenUnofficial(temperature=config.llm.temperature, model=config.llm.name, max_tokens=2048)
+        else:
+            llm = OpenAI(temperature=config.llm.temperature, model=config.llm.name, max_tokens=2048)
+
         service_context = ServiceContext.from_defaults(llm=llm, embed_model=embed_model)
         set_global_service_context(service_context)
         rerank_k = config.milvus.rerank_topk

--- a/executor.py
+++ b/executor.py
@@ -12,7 +12,7 @@ from llama_index import ServiceContext, StorageContext
 from llama_index import set_global_service_context
 from llama_index import VectorStoreIndex, SimpleDirectoryReader, Document
 from llama_index.llms import OpenAI
-from QwenLLM import QwenUnofficial
+from custom.llms.QwenLLM import QwenUnofficial
 from llama_index.readers.file.flat_reader import FlatReader
 from llama_index.vector_stores import MilvusVectorStore
 from llama_index.embeddings import HuggingFaceEmbedding


### PR DESCRIPTION
国内的几家都试了下，只有通义千问返回的是正确的。
看了下[llama_index支持的大模型](https://docs.llamaindex.ai/en/stable/api_reference/llms.html#llm-implementations)，国内大模型都不在上面。
按它的Interface实现了一个[QwenLLM](https://github.com/wxywb/history_rag/pull/8/commits/4c4d59bcf42d0b56faf8ce0c535193f11d0632fe), 可以直接用通义千问的API

用法：
1. 根据[教程](https://help.aliyun.com/zh/dashscope/developer-reference/api-details)安装sdk, 设置key
2. config.yaml 中 llm.name 设置成 "qwen" (用的是qwen-max模型，目前免费)
3. 按原教程用就可以了

问题：
1. 代码好像会对同一个问题多轮提问，以优化回答，API大部分都会回复："新的上下文没什么帮助..."
2.  Qwen 对于部分问题会报错 "DataInspectionFailed"。这个没有什么办法，好像只有API会这样回复，我在代码里把prompt打印出来，直接到网页里问就没问题，问了阿里的工程师，还没回复。

样例：
![2024-01-26-232909_2401x231_scrot](https://github.com/wxywb/history_rag/assets/39115827/d49c0550-10f5-4862-9939-697ed9dcc8c9)
![2024-01-26-232953_2418x210_scrot](https://github.com/wxywb/history_rag/assets/39115827/47687e76-8115-4164-af13-c83c5fcff6cb)
