### PR TITLE
MilvusVectorStore 依赖的版本， host、port参数不适用，更新为 uri参数

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -129,8 +129,7 @@ class MilvusExecutor(Executor):
     def build_index(self, path, overwrite):
         config = self.config
         vector_store = MilvusVectorStore(
-            host = config.milvus.host,
-            port = config.milvus.port,
+            uri = f"http://{config.milvus.host}:{config.milvus.port}",
             collection_name = config.milvus.collection_name,
             overwrite=overwrite,
             dim=config.embedding.dim)
@@ -161,8 +160,7 @@ class MilvusExecutor(Executor):
     def _get_index(self):
         config = self.config
         vector_store = MilvusVectorStore(
-            host = config.milvus.host,
-            port = config.milvus.port,
+            uri = f"http://{config.milvus.host}:{config.milvus.port}",
             collection_name = config.milvus.collection_name,
             dim=config.embedding.dim)
         self.index = VectorStoreIndex.from_vector_store(vector_store=vector_store)


### PR DESCRIPTION
https://github.com/run-llama/llama_index/blob/55e3011d293e1149a20275cd48615fe2b51f978a/llama_index/vector_stores/milvus.py#L90 

https://milvus.io/docs/manage_connection.md

`llama_index` 和 `milvus` sdk 都更新为 uri 参数了