### PR TITLE
修复pipeline 无法从GitHub批量构建索引的bug，增加qwen-max等模型名字匹配

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -143,9 +143,9 @@ class MilvusExecutor(Executor):
 
         service_context = ServiceContext.from_defaults(llm=llm, embed_model=embed_model)
         set_global_service_context(service_context)
-        # rerank_k = config.milvus.rerank_topk
-        # self.rerank_postprocessor = SentenceTransformerRerank(
-        #     model=config.rerank.name, top_n=rerank_k)
+        rerank_k = config.milvus.rerank_topk
+        self.rerank_postprocessor = SentenceTransformerRerank(
+            model=config.rerank.name, top_n=rerank_k)
         self._milvus_client = None
         self._debug = False
         

--- a/executor.py
+++ b/executor.py
@@ -129,7 +129,7 @@ class MilvusExecutor(Executor):
         embed_model = HuggingFaceEmbedding(model_name=config.embedding.name)
 
         # 使用Qwen 通义千问模型
-        if config.llm.name == "qwen":
+        if config.llm.name.find("qwen") != -1:
             llm = QwenUnofficial(temperature=config.llm.temperature, model=config.llm.name, max_tokens=2048)
         elif config.llm.name.find("gemini") != -1:
             llm = Gemini(temperature=config.llm.temperature, model_name=config.llm.name, max_tokens=2048)
@@ -256,7 +256,7 @@ class PipelineExecutor(Executor):
         self.config = config
         self._debug = False
 
-        if config.llm.name == "qwen":
+        if config.llm.name.find("qwen") != -1:
             llm = QwenUnofficial(temperature=config.llm.temperature, model=config.llm.name, max_tokens=2048)
         elif config.llm.name.find("gemini") != -1:
             llm = Gemini(model_name=config.llm.name, temperature=config.llm.temperature, max_tokens=2048)

--- a/executor.py
+++ b/executor.py
@@ -68,7 +68,6 @@ def is_github_folder_url(url):
 
 def get_branch_head_sha(owner, repo, branch):
     url = f"https://api.github.com/repos/{owner}/{repo}/git/ref/heads/{branch}"
-    print(f'getting sha from {url}')
     response = requests.get(url)
     data = response.json()
     sha = data['object']['sha']
@@ -82,7 +81,6 @@ def get_github_repo_contents(repo_url):
     folder_path = '/'.join(repo_url.split('/')[6:])
     sha = get_branch_head_sha(repo_owner, repo_name, branch)
     url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/trees/{sha}?recursive=1"
-    print(url)
     try:
         response = requests.get(url)
         if response.status_code == 200:


### PR DESCRIPTION
源代码直接get请求会得到400错误而报错
```
# original
def get_github_repo_contents(repo_url):
    # GET https://raw.githubusercontent.com/wxywb/history_rag/master/data/history_24/  无法获得json数据
    response = requests.get(repo_url)
```

修改为直接使用api.github.com获取文件目录

